### PR TITLE
fix: interactive media in bubbles (#1) + optional FlashList engine (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### ✨ Features
+- **Row-wide press target for reactions**: the long-press surface now spans the whole message row instead of just the bubble, so pressing the empty space beside a bubble opens the reaction picker - matching Telegram on Android. The message row is full-width now and the 70% width cap moved from the row onto the bubble itself (bubbles beside an avatar therefore get slightly more room).
+- **`isMessageGestureEnabled`**: opt a message's *bubble* out of that surface (accepts a bool or a per-message predicate) for content that must own its touches - e.g. `isMessageGestureEnabled={message => !message.video}`. The surface moves behind the bubble rather than disappearing, so long-pressing beside the bubble still opens the picker and reactions are never lost for that message.
+- **Optional FlashList engine** ([#3](https://github.com/kesha-antonov/react-native-chat/issues/3)): set `isFlashListEnabled` to render messages with `@shopify/flash-list` v2 instead of `FlatList`, which recycles rows and removes the `VirtualizedList: You have a large list that is slow to update` warning on long histories. `@shopify/flash-list` is an **optional** peer dependency - when it is missing the prop is ignored, a warning is logged, and `FlatList` is used. The chat wires FlashList's `maintainVisibleContentPosition` for you (`startRenderingFromBottom` on non-inverted lists, `autoscrollToBottomThreshold: 0.2`), and `listProps` still overrides everything. `isInverted`, the floating day header, infinite scroll and the scroll-to-bottom button all keep working.
+
+### 🐛 Bug Fixes
+- **Video controls no longer dead when reactions are enabled** ([#1](https://github.com/kesha-antonov/react-native-chat/issues/1)): the bubble's reaction gestures ran with the default `cancelsTouchesInView`, so on iOS they cancelled touches on native subviews and a `react-native-video` / `expo-video` player rendered through `renderMessageVideo` never got its play/seek/fullscreen taps. Both the tap and long-press recognizers now set `cancelsTouchesInView(false)`, and the tap gesture is only attached when `onPressMessage` is actually provided instead of always competing for touches.
+
 ## [4.1.0] - 2026-06-19
 
 ### ✨ Features

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ function ChatScreen() {
 - **`renderChatEmpty`** _(Component | Function)_ - Custom component to render in the ListView when messages are empty
 - **`renderChatFooter`** _(Component | Function)_ - Custom component to render below the MessagesContainer (separate from the ListView)
 - **`listProps`** _(Object)_ - Extra props to be passed to the messages [`<FlatList>`](https://reactnative.dev/docs/flatlist). Supports all FlatList props including `maintainVisibleContentPosition` for keeping scroll position when new messages arrive (useful for AI chatbots).
+- **`isFlashListEnabled`** _(Bool)_ - Render messages with [`@shopify/flash-list`](https://shopify.github.io/flash-list/) v2 instead of `FlatList`; default is `false`. See [FlashList](#flashlist-opt-in).
 
 ### Message Bubbles & Content
 
@@ -361,6 +362,7 @@ function ChatScreen() {
 - **`isCustomViewBottom`** _(Bool)_ - Determine whether renderCustomView is displayed before or after the text, image and video views; default is `false`
 - **`onPressMessage`** _(Function(`context`, `message`))_ - Callback when a message bubble is pressed
 - **`onLongPressMessage`** _(Function(`context`, `message`))_ - Callback when a message bubble is long-pressed; you can use this to show action sheets (e.g., copy, delete, reply)
+- **`isMessageGestureEnabled`** _(Bool | Function(`message`))_ - Whether the bubble itself is part of the row's tap / long-press surface that `reactions` relies on; default is `true`. Pass `false`, or a predicate, for messages that render natively interactive content - the row beside the bubble stays pressable either way. See [Interactive content inside bubbles](#interactive-content-inside-bubbles-video-players-maps).
 - **`imageProps`** _(Object)_ - Extra props to be passed to the [`<Image>`](https://reactnative.dev/docs/image) component created by the default `renderMessageImage`
 - **`imageStyle`** _(Object)_ - Custom style for message images
 - **`videoProps`** _(Object)_ - Extra props to be passed to the video component created by the required `renderMessageVideo`
@@ -789,6 +791,56 @@ Message text is automatically scanned for URLs, emails, and phone numbers; hasht
 ```
 
 For full control, pass custom `matchers` (`{ type, pattern, getLinkUrl?, getLinkText?, renderLink?, onPress? }[]`) to add or override patterns. See the Links example in the [example app](#-example-app).
+
+### Interactive content inside bubbles (video players, maps)
+
+When `reactions` are enabled, the long-press surface spans the **whole message row** - the bubble *and* the empty space beside it, the way Telegram behaves on Android. (A tap gesture is added on top only when `onPressMessage` is set.) Those recognizers do not cancel touches on native subviews, so a `react-native-video` / `expo-video` player rendered through `renderMessageVideo` keeps its native `controls` interactive.
+
+If a message must own every touch that lands on it, set `isMessageGestureEnabled` to `false` for it. The gesture surface then drops *behind* the bubble: the bubble's content takes its touches, and long-pressing the row next to the bubble still opens the picker - so reactions are never lost for that message.
+
+```tsx
+<Chat
+  reactions={{ isEnabled: true, onReactionPress }}
+  renderMessageVideo={props => <Video source={{ uri: props.currentMessage.video }} controls style={styles.video} />}
+  // the video owns its controls; long-press beside the bubble still reacts
+  isMessageGestureEnabled={message => !message.video}
+/>
+```
+
+### FlashList (opt-in)
+
+On long histories `FlatList` can log `VirtualizedList: You have a large list that is slow to update`. [FlashList](https://shopify.github.io/flash-list/) v2 recycles rows instead of keeping them mounted, which removes that class of stall. It is supported as an **optional** dependency - install it yourself and flip one prop:
+
+```bash
+yarn add @shopify/flash-list
+```
+
+```jsx
+<Chat messages={messages} user={user} isFlashListEnabled />
+```
+
+Everything else keeps working: `isInverted`, the floating day header, `loadEarlierMessagesProps` infinite scroll, the scroll-to-bottom button, and `listProps` (spread last, so it overrides the defaults below).
+
+The chat sets FlashList's `maintainVisibleContentPosition` for you - `startRenderingFromBottom` when `isInverted={false}`, plus `autoscrollToBottomThreshold: 0.2` so new messages follow the viewport only when you are already at the bottom. Override it through `listProps` if you want different thresholds:
+
+```jsx
+<Chat
+  isFlashListEnabled
+  listProps={{
+    maintainVisibleContentPosition: {
+      autoscrollToBottomThreshold: 0.1,
+      animateAutoScrollToBottom: false,
+    },
+  }}
+  {...props}
+/>
+```
+
+Notes:
+
+- FlashList v2 requires the **New Architecture**. On the old architecture it falls back to a slower JS path.
+- `FlatList`-only knobs (`windowSize`, `maxToRenderPerBatch`, `initialNumToRender`, `updateCellsBatchingPeriod`, `removeClippedSubviews`) are not forwarded to FlashList - it sizes its own render window.
+- If `@shopify/flash-list` is not installed, the prop is ignored, a warning is logged, and `FlatList` is used.
 
 ### Copy to Clipboard
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@react-native/eslint-config": "0.81.5",
     "@react-native/metro-config": "0.81.5",
     "@react-native/typescript-config": "0.81.5",
+    "@shopify/flash-list": "^2.3.2",
     "@stylistic/eslint-plugin": "^3.1.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
@@ -105,6 +106,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
+    "@shopify/flash-list": "*",
     "react": ">=18.0.0",
     "react-native": "*",
     "react-native-gesture-handler": ">=2.0.0",
@@ -115,5 +117,10 @@
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "engines": {
     "node": ">=20"
+  },
+  "peerDependenciesMeta": {
+    "@shopify/flash-list": {
+      "optional": true
+    }
   }
 }

--- a/src/Bubble/index.tsx
+++ b/src/Bubble/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react'
 import {
   View,
   Pressable,
+  StyleSheet,
   Text } from 'react-native'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import Animated, {
@@ -61,9 +62,19 @@ export const Bubble = <TMessage extends IMessage = IMessage>(props: BubbleProps<
     onPressMessage: onPressMessageProp,
     onLongPressMessage: onLongPressMessageProp,
     reactions,
+    isMessageGestureEnabled = true,
   } = props
 
   const context = useChatContext()
+
+  // Consumers can hand the touches back to natively interactive content
+  // (video controls, maps, WebViews) on a per-message basis.
+  const isGestureEnabled = useMemo(() => {
+    if (typeof isMessageGestureEnabled === 'function')
+      return currentMessage ? isMessageGestureEnabled(currentMessage) : true
+
+    return isMessageGestureEnabled
+  }, [isMessageGestureEnabled, currentMessage])
 
   const bubbleContainerRef = useRef<View>(null)
 
@@ -104,6 +115,9 @@ export const Bubble = <TMessage extends IMessage = IMessage>(props: BubbleProps<
   const tapGesture = useMemo(
     () =>
       Gesture.Tap()
+        // Keep native subviews (video controls, maps, native buttons) receiving
+        // touches. iOS cancels them by default the moment this recognizer wins.
+        .cancelsTouchesInView(false)
         .runOnJS(true)
         .onEnd((_e, success) => {
           if (success)
@@ -115,6 +129,7 @@ export const Bubble = <TMessage extends IMessage = IMessage>(props: BubbleProps<
   const longPressGesture = useMemo(
     () =>
       Gesture.LongPress()
+        .cancelsTouchesInView(false)
         .onBegin(() => {
           messageScale.value = withTiming(SCALE_PRESSED, {
             duration: SCALE_DURATION_IN,
@@ -139,9 +154,13 @@ export const Bubble = <TMessage extends IMessage = IMessage>(props: BubbleProps<
   // Exclusive composition: a long-press wins over the tap when held long
   // enough; a quick lift lets the tap through. Both share the onBegin/onFinalize
   // scale animation because onBegin always fires before either gesture wins.
+  // The tap is only attached when there is something to call - otherwise it
+  // would compete with interactive content inside the bubble for no reason.
   const reactionsGesture = useMemo(
-    () => Gesture.Exclusive(longPressGesture, tapGesture),
-    [longPressGesture, tapGesture]
+    () => onPressMessageProp
+      ? Gesture.Exclusive(longPressGesture, tapGesture)
+      : longPressGesture,
+    [longPressGesture, tapGesture, onPressMessageProp]
   )
 
   const styledBubbleToNext = useMemo(() => {
@@ -491,6 +510,16 @@ export const Bubble = <TMessage extends IMessage = IMessage>(props: BubbleProps<
     wrapperStyle?.[position],
   ], [position, styledBubbleToNext, styledBubbleToPrevious, wrapperStyle])
 
+  const containerStyleList = useMemo(() => [
+    getStyleWithPosition(styles, 'container', position),
+    containerStyle?.[position],
+  ], [position, containerStyle])
+
+  const rowSurfaceStyle = useMemo(
+    () => getStyleWithPosition(styles, 'rowSurface', position),
+    [position]
+  )
+
   const renderReactionsDisplay = useCallback(() => {
     const currentReactions = currentMessage?.reactions
     if (!currentReactions || currentReactions.length === 0)
@@ -539,37 +568,65 @@ export const Bubble = <TMessage extends IMessage = IMessage>(props: BubbleProps<
     return <ReactionPicker {...pickerProps} />
   }, [reactions, isPickerVisible, currentMessage, position, pickerAnchor])
 
-  if (reactions?.isEnabled)
-    // Reactions path: the Animated.View carries only the scale transform,
-    // keeping the animation isolated from the static bubble styles on the
-    // inner View. Tap/long-press are handled by the composed gesture.
+  // Reactions path: the Animated.View carries only the scale transform, keeping
+  // the animation isolated from the static bubble styles on the inner View.
+  // Tap/long-press are handled by the composed gesture.
+  if (reactions?.isEnabled) {
+    // `rowSurface` spans the whole message row, so a long-press in the empty
+    // space beside the bubble opens the picker too - the way Telegram behaves.
+    const bubbleRow = (
+      <View style={rowSurfaceStyle}>
+        <Animated.View style={bubbleScaleStyle}>
+          <View style={wrapperStyleList} ref={bubbleContainerRef}>
+            {renderBubbleBody()}
+          </View>
+        </Animated.View>
+      </View>
+    )
+
     return (
-      <Animated.View style={containerStyle?.[position]} ref={bubbleContainerRef}>
-        <GestureDetector gesture={reactionsGesture}>
-          <Animated.View style={bubbleScaleStyle}>
-            <View style={wrapperStyleList}>
-              {renderBubbleBody()}
-            </View>
-          </Animated.View>
-        </GestureDetector>
+      <Animated.View style={containerStyleList}>
+        {isGestureEnabled
+          ? (
+            <GestureDetector gesture={reactionsGesture}>
+              {bubbleRow}
+            </GestureDetector>
+          )
+          : (
+            // Gestures are off for this message, so the surface drops *behind*
+            // the bubble: the bubble's own content (native video controls, a
+            // map, a WebView) keeps every touch that lands on it, while the rest
+            // of the row still opens the picker.
+            <>
+              <GestureDetector gesture={reactionsGesture}>
+                <View style={StyleSheet.absoluteFill} />
+              </GestureDetector>
+              {bubbleRow}
+            </>
+          )}
         {renderQuickReplies()}
         {renderReactionsDisplay()}
         {renderReactionPickerModal()}
       </Animated.View>
     )
+  }
 
   // Default path: unchanged behaviour for existing users, preserving
   // touchableProps, native press feedback, and the onLongPressMessage callback.
   return (
-    <View style={containerStyle?.[position]}>
+    <View style={containerStyleList}>
       <View style={wrapperStyleList}>
-        <Pressable
-          onPress={onPress}
-          onLongPress={onLongPress}
-          {...props.touchableProps}
-        >
-          {renderBubbleBody()}
-        </Pressable>
+        {isGestureEnabled
+          ? (
+            <Pressable
+              onPress={onPress}
+              onLongPress={onLongPress}
+              {...props.touchableProps}
+            >
+              {renderBubbleBody()}
+            </Pressable>
+          )
+          : renderBubbleBody()}
       </View>
       {renderQuickReplies()}
     </View>

--- a/src/Bubble/styles.ts
+++ b/src/Bubble/styles.ts
@@ -2,9 +2,34 @@ import { StyleSheet } from 'react-native'
 import { Color } from '../Color'
 
 const styles = StyleSheet.create({
+  // Fills the message row so the pressable surface reaches the far edge, with
+  // the bubble itself pinned to the sender's side.
+  container: {
+    flex: 1,
+  },
+  container_left: {
+    alignItems: 'flex-start',
+  },
+  container_right: {
+    alignItems: 'flex-end',
+  },
+
+  // Full-width band holding the bubble - this is what the reactions gesture is
+  // attached to, so the whole row responds and not just the bubble.
+  rowSurface: {
+    alignSelf: 'stretch',
+  },
+  rowSurface_left: {
+    alignItems: 'flex-start',
+  },
+  rowSurface_right: {
+    alignItems: 'flex-end',
+  },
+
   wrapper: {
     borderRadius: 15,
     minHeight: 20,
+    maxWidth: '70%',
   },
   wrapper_left: {
     backgroundColor: Color.leftBubbleBackground,

--- a/src/Bubble/types.ts
+++ b/src/Bubble/types.ts
@@ -104,4 +104,14 @@ export interface BubbleProps<TMessage extends IMessage> {
   messageReply?: BubbleReplyProps<TMessage>
   /** Emoji reactions configuration */
   reactions?: ReactionsProps<TMessage>
+  /**
+   * Controls whether the bubble itself is part of the row's tap / long-press
+   * surface that `reactions` relies on. Pass `false` (or a predicate returning
+   * `false`) for messages that render natively interactive content - a video
+   * player with its own controls, a map, a WebView - whose touches must not
+   * compete with the bubble. The surface beside the bubble stays pressable
+   * either way, so reactions are never lost for that message.
+   * @default true
+   */
+  isMessageGestureEnabled?: boolean | ((message: TMessage) => boolean)
 }

--- a/src/Chat/types.ts
+++ b/src/Chat/types.ts
@@ -165,4 +165,14 @@ export interface ChatProps<TMessage extends IMessage> extends Partial<Omit<Messa
   reply?: ReplyProps<TMessage>
   /** Emoji reactions configuration */
   reactions?: ReactionsProps<TMessage>
+  /**
+   * Controls whether the bubble itself is part of the row's tap / long-press
+   * surface that `reactions` relies on. Pass `false` (or a predicate returning
+   * `false`) for messages that render natively interactive content - a video
+   * player with its own controls, a map, a WebView - whose touches must not
+   * compete with the bubble. The surface beside the bubble stays pressable
+   * either way, so reactions are never lost for that message.
+   * @default true
+   */
+  isMessageGestureEnabled?: boolean | ((message: TMessage) => boolean)
 }

--- a/src/Message/styles.ts
+++ b/src/Message/styles.ts
@@ -1,18 +1,18 @@
 import { StyleSheet } from 'react-native'
 
 export default StyleSheet.create({
+  // The row spans the full width so a long-press anywhere beside the bubble
+  // still opens the reactions (Telegram-style). The 70% cap lives on the bubble
+  // itself (see `wrapper` in Bubble/styles).
   container: {
     flexDirection: 'row',
     alignItems: 'flex-end',
-    maxWidth: '70%',
+    marginHorizontal: 8,
   },
   container_left: {
     justifyContent: 'flex-start',
-    marginLeft: 8,
   },
   container_right: {
     justifyContent: 'flex-end',
-    marginRight: 8,
-    alignSelf: 'flex-end',
   },
 })

--- a/src/MessagesContainer/FlashList.ts
+++ b/src/MessagesContainer/FlashList.ts
@@ -1,0 +1,25 @@
+import Animated from 'react-native-reanimated'
+
+// Optional high-performance list engine. Resolved through a try/catch require so
+// the bundle works whether or not the consumer installed `@shopify/flash-list`
+// (Metro treats try/catch-wrapped requires as optional dependencies).
+let flashList: any = null
+try {
+  flashList = require('@shopify/flash-list')
+} catch {
+  flashList = null
+}
+
+const FlashListComponent = flashList?.FlashList ?? null
+
+export const isFlashListAvailable = !!FlashListComponent
+
+/**
+ * FlashList wrapped by Reanimated so the messages container can keep driving the
+ * floating day header and the scroll-to-bottom button from a single
+ * `useAnimatedScrollHandler`, exactly like it does with FlatList.
+ * `null` when `@shopify/flash-list` is not installed.
+ */
+export const AnimatedFlashList: any = FlashListComponent
+  ? Animated.createAnimatedComponent(FlashListComponent)
+  : null

--- a/src/MessagesContainer/index.tsx
+++ b/src/MessagesContainer/index.tsx
@@ -4,6 +4,8 @@ import {
   LayoutChangeEvent,
   ListRenderItemInfo,
   CellRendererProps,
+  StyleProp,
+  ViewStyle,
   Text } from 'react-native'
 import { Pressable } from 'react-native-gesture-handler'
 import Animated, { runOnJS, ScrollEvent, useAnimatedScrollHandler, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated'
@@ -16,10 +18,19 @@ import { isSameDay, useCallbackThrottled } from '../utils'
 import { DayAnimated } from './components/DayAnimated'
 import { Item } from './components/Item'
 import { ItemProps } from './components/Item/types'
+import { AnimatedFlashList, isFlashListAvailable } from './FlashList'
 import styles from './styles'
 import { MessagesContainerProps, DaysPositions, AnimatedFlatList } from './types'
 
 export * from './types'
+
+/** Props FlashList hands to its `CellRendererComponent`. */
+interface FlashListCellProps {
+  index: number
+  style?: StyleProp<ViewStyle>
+  onLayout?: (event: LayoutChangeEvent) => void
+  children?: React.ReactNode
+}
 
 export const MessagesContainer = <TMessage extends IMessage>(props: MessagesContainerProps<TMessage>) => {
   const {
@@ -42,7 +53,17 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
     scrollToBottomComponent: scrollToBottomComponentProp,
     renderDay: renderDayProp,
     isDayAnimationEnabled = true,
+    isFlashListEnabled = false,
   } = props
+
+  const isFlashList = isFlashListEnabled && isFlashListAvailable
+
+  useEffect(() => {
+    if (isFlashListEnabled && !isFlashListAvailable)
+      warning(
+        'Chat: `isFlashListEnabled` is set but `@shopify/flash-list` is not installed - falling back to FlatList'
+      )
+  }, [isFlashListEnabled])
 
   const listPropsOnScrollProp = listProps?.onScroll
 
@@ -336,49 +357,54 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
 
   const keyExtractor = useCallback((item: unknown) => (item as TMessage)._id.toString(), [])
 
+  // Records where each message sits in the content so the floating day header
+  // knows which day is currently on screen. Shared by both cell renderers.
+  const trackDayPosition = useCallback((message: IMessage | undefined, layout: { y: number, height: number }) => {
+    // Only track positions when day animation is enabled
+    if (!isDayAnimationEnabled || !message)
+      return
+
+    const id = message._id.toString()
+    const { y, height } = layout
+
+    const newValue = {
+      y,
+      height,
+      createdAt: new Date(message.createdAt).getTime(),
+    }
+
+    daysPositions.modify(value => {
+      'worklet'
+
+      const isSameDay = (date1: number, date2: number) => {
+        const d1 = new Date(date1)
+        const d2 = new Date(date2)
+
+        return (
+          d1.getDate() === d2.getDate() &&
+          d1.getMonth() === d2.getMonth() &&
+          d1.getFullYear() === d2.getFullYear()
+        )
+      }
+
+      for (const [key, item] of Object.entries(value))
+        if (isSameDay(newValue.createdAt, item.createdAt) && (isInverted ? item.y <= newValue.y : item.y >= newValue.y)) {
+          delete value[key]
+          break
+        }
+
+      // @ts-expect-error: https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue#remarks
+      value[id] = newValue
+      return value
+    })
+  }, [daysPositions, isInverted, isDayAnimationEnabled])
+
   const renderCell = useCallback((props: CellRendererProps<unknown>) => {
     const { item, onLayout: onLayoutProp, children } = props
-    const id = (item as IMessage)._id.toString()
 
     const handleOnLayout = (event: LayoutChangeEvent) => {
       onLayoutProp?.(event)
-
-      // Only track positions when day animation is enabled
-      if (!isDayAnimationEnabled)
-        return
-
-      const { y, height } = event.nativeEvent.layout
-
-      const newValue = {
-        y,
-        height,
-        createdAt: new Date((item as IMessage).createdAt).getTime(),
-      }
-
-      daysPositions.modify(value => {
-        'worklet'
-
-        const isSameDay = (date1: number, date2: number) => {
-          const d1 = new Date(date1)
-          const d2 = new Date(date2)
-
-          return (
-            d1.getDate() === d2.getDate() &&
-            d1.getMonth() === d2.getMonth() &&
-            d1.getFullYear() === d2.getFullYear()
-          )
-        }
-
-        for (const [key, item] of Object.entries(value))
-          if (isSameDay(newValue.createdAt, item.createdAt) && (isInverted ? item.y <= newValue.y : item.y >= newValue.y)) {
-            delete value[key]
-            break
-          }
-
-        // @ts-expect-error: https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue#remarks
-        value[id] = newValue
-        return value
-      })
+      trackDayPosition(item as IMessage, event.nativeEvent.layout)
     }
 
     return (
@@ -389,7 +415,31 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
         {children}
       </View>
     )
-  }, [daysPositions, isInverted, isDayAnimationEnabled])
+  }, [trackDayPosition])
+
+  // FlashList recycles cells and hands its CellRendererComponent only an
+  // `index` (no `item`), so the message is looked up through a ref to keep the
+  // component identity stable - recreating it would remount every row.
+  const messagesRef = useRef(messages)
+  messagesRef.current = messages
+
+  const FlashListCell = useMemo(() => {
+    const Cell = React.forwardRef<View, FlashListCellProps>(({ index, onLayout: onLayoutProp, children, ...rest }, ref) => {
+      const handleOnLayout = (event: LayoutChangeEvent) => {
+        onLayoutProp?.(event)
+        trackDayPosition(messagesRef.current[index], event.nativeEvent.layout)
+      }
+
+      return (
+        <View ref={ref} {...rest} onLayout={handleOnLayout}>
+          {children}
+        </View>
+      )
+    })
+
+    Cell.displayName = 'FlashListCell'
+    return Cell
+  }, [trackDayPosition])
 
   const scrollHandler = useAnimatedScrollHandler({
     onScroll: event => {
@@ -439,6 +489,26 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
     })
   }, [messages, daysPositions, isInverted, isDayAnimationEnabled])
 
+  // Props shared by both list engines. FlatList-only and FlashList-only options
+  // are added at the call sites below.
+  const commonListProps = {
+    ref: forwardRef,
+    keyExtractor,
+    data: messages,
+    renderItem,
+    inverted: isInverted,
+    style: stylesCommon.fill,
+    contentContainerStyle: styles.messagesContainer,
+    ListEmptyComponent: renderChatEmpty,
+    ListFooterComponent: isInverted ? ListHeaderComponent : <>{ListFooterComponent}</>,
+    ListHeaderComponent: isInverted ? <>{ListFooterComponent}</> : ListHeaderComponent,
+    scrollEventThrottle: 1,
+    onEndReached,
+    onEndReachedThreshold: 0.1,
+    keyboardDismissMode: 'interactive' as const,
+    keyboardShouldPersistTaps: 'handled' as const,
+  }
+
   return (
     <View
       style={[
@@ -446,32 +516,33 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
         isAlignedTop ? styles.containerAlignTop : stylesCommon.fill,
       ]}
     >
-      <AnimatedFlatList
-        ref={forwardRef}
-        keyExtractor={keyExtractor}
-        data={messages}
-        renderItem={renderItem}
-        inverted={isInverted}
-        automaticallyAdjustContentInsets={false}
-        style={stylesCommon.fill}
-        contentContainerStyle={styles.messagesContainer}
-        ListEmptyComponent={renderChatEmpty}
-        ListFooterComponent={
-          isInverted ? ListHeaderComponent : <>{ListFooterComponent}</>
-        }
-        ListHeaderComponent={
-          isInverted ? <>{ListFooterComponent}</> : ListHeaderComponent
-        }
-        scrollEventThrottle={1}
-        onEndReached={onEndReached}
-        onEndReachedThreshold={0.1}
-        keyboardDismissMode='interactive'
-        keyboardShouldPersistTaps='handled'
-        {...listProps}
-        onScroll={scrollHandler}
-        onLayout={onLayoutList}
-        CellRendererComponent={renderCell}
-      />
+      {isFlashList
+        ? (
+          <AnimatedFlashList
+            {...commonListProps}
+            // FlashList v2 keeps the viewport pinned to the newest message on
+            // its own; a non-inverted chat additionally wants the first render
+            // to start at the bottom. Overridable through `listProps`.
+            maintainVisibleContentPosition={{
+              startRenderingFromBottom: !isInverted,
+              autoscrollToBottomThreshold: 0.2,
+            }}
+            {...listProps}
+            onScroll={scrollHandler}
+            onLayout={onLayoutList}
+            CellRendererComponent={FlashListCell}
+          />
+        )
+        : (
+          <AnimatedFlatList
+            {...commonListProps}
+            automaticallyAdjustContentInsets={false}
+            {...listProps}
+            onScroll={scrollHandler}
+            onLayout={onLayoutList}
+            CellRendererComponent={renderCell}
+          />
+        )}
       <ScrollToBottomWrapper />
       {isDayAnimationEnabled && (
         <DayAnimated

--- a/src/MessagesContainer/types.ts
+++ b/src/MessagesContainer/types.ts
@@ -50,6 +50,15 @@ export interface MessagesContainerProps<TMessage extends IMessage = IMessage>
   user?: User
   /** Additional props for FlatList */
   listProps?: AnimatedListProps<TMessage>
+  /**
+   * Render messages with `@shopify/flash-list` (v2) instead of `FlatList`.
+   * Requires the optional `@shopify/flash-list` peer dependency and the New
+   * Architecture; falls back to `FlatList` with a warning when it is missing.
+   * FlashList recycles rows, which removes the `VirtualizedList: You have a
+   * large list that is slow to update` warning on long histories.
+   * @default false
+   */
+  isFlashListEnabled?: boolean
   /** Reverses display order of messages; default is true */
   isInverted?: boolean
   /** Controls whether or not the message bubbles appear at the top of the chat */

--- a/src/__tests__/Bubble.test.tsx
+++ b/src/__tests__/Bubble.test.tsx
@@ -1,8 +1,24 @@
 import React from 'react'
-import { render } from '@testing-library/react-native'
+import { render, within } from '@testing-library/react-native'
+import { Gesture } from 'react-native-gesture-handler'
 
 import { Bubble } from '..'
 import { DEFAULT_TEST_MESSAGE } from './data'
+
+jest.mock('react-native-gesture-handler', () => {
+  const actual = jest.requireActual('react-native-gesture-handler')
+  const ReactActual = jest.requireActual('react')
+  const { View } = jest.requireActual('react-native')
+
+  return {
+    ...actual,
+    // Tag the detector so tests can assert whether the bubble attached gestures.
+    GestureDetector: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(View, { testID: 'bubble-gesture-detector' }, children),
+  }
+})
+
+const REACTIONS = { isEnabled: true, onReactionPress: jest.fn() }
 
 it('should render <Bubble /> and compare with snapshot', () => {
   const { toJSON } = render(
@@ -14,4 +30,119 @@ it('should render <Bubble /> and compare with snapshot', () => {
   )
 
   expect(toJSON()).toMatchSnapshot()
+})
+
+describe('bubble gestures', () => {
+  it('covers the bubble with the row gesture when reactions are enabled', () => {
+    const { getByTestId } = render(
+      <Bubble
+        user={{ _id: 1 }}
+        currentMessage={DEFAULT_TEST_MESSAGE}
+        position='left'
+        reactions={REACTIONS}
+      />
+    )
+
+    const detector = getByTestId('bubble-gesture-detector')
+    expect(within(detector).queryByText(DEFAULT_TEST_MESSAGE.text)).not.toBeNull()
+  })
+
+  it('keeps the row gesture but drops the bubble when isMessageGestureEnabled is false', () => {
+    const { getByTestId, queryByText } = render(
+      <Bubble
+        user={{ _id: 1 }}
+        currentMessage={DEFAULT_TEST_MESSAGE}
+        position='left'
+        reactions={REACTIONS}
+        isMessageGestureEnabled={false}
+      />
+    )
+
+    // the surface beside the bubble still opens the picker...
+    const detector = getByTestId('bubble-gesture-detector')
+    // ...but the bubble body sits outside it and keeps its own touches
+    expect(within(detector).queryByText(DEFAULT_TEST_MESSAGE.text)).toBeNull()
+    expect(queryByText(DEFAULT_TEST_MESSAGE.text)).not.toBeNull()
+  })
+
+  it('accepts a per-message isMessageGestureEnabled predicate', () => {
+    const videoMessage = { ...DEFAULT_TEST_MESSAGE, video: 'https://example.com/v.mp4' }
+    const isMessageGestureEnabled = (message: typeof videoMessage) => !message.video
+
+    const { getByTestId, rerender } = render(
+      <Bubble
+        user={{ _id: 1 }}
+        currentMessage={videoMessage}
+        position='left'
+        reactions={REACTIONS}
+        isMessageGestureEnabled={isMessageGestureEnabled}
+      />
+    )
+
+    expect(within(getByTestId('bubble-gesture-detector')).queryByText(DEFAULT_TEST_MESSAGE.text)).toBeNull()
+
+    rerender(
+      <Bubble
+        user={{ _id: 1 }}
+        currentMessage={DEFAULT_TEST_MESSAGE}
+        position='left'
+        reactions={REACTIONS}
+        isMessageGestureEnabled={isMessageGestureEnabled}
+      />
+    )
+
+    expect(within(getByTestId('bubble-gesture-detector')).queryByText(DEFAULT_TEST_MESSAGE.text)).not.toBeNull()
+  })
+
+  // Regression: gesture recognizers cancelled touches on native subviews, so
+  // video controls rendered through renderMessageVideo were dead (#1).
+  it('does not cancel touches in native subviews', () => {
+    const tapSpy = jest.spyOn(Gesture, 'Tap')
+    const longPressSpy = jest.spyOn(Gesture, 'LongPress')
+
+    render(
+      <Bubble
+        user={{ _id: 1 }}
+        currentMessage={DEFAULT_TEST_MESSAGE}
+        position='left'
+        reactions={REACTIONS}
+        onPressMessage={jest.fn()}
+      />
+    )
+
+    expect(tapSpy.mock.results[0]!.value.config.cancelsTouchesInView).toBe(false)
+    expect(longPressSpy.mock.results[0]!.value.config.cancelsTouchesInView).toBe(false)
+
+    tapSpy.mockRestore()
+    longPressSpy.mockRestore()
+  })
+
+  it('only composes the tap gesture when onPressMessage is provided', () => {
+    const exclusiveSpy = jest.spyOn(Gesture, 'Exclusive')
+
+    render(
+      <Bubble
+        user={{ _id: 1 }}
+        currentMessage={DEFAULT_TEST_MESSAGE}
+        position='left'
+        reactions={REACTIONS}
+      />
+    )
+
+    expect(exclusiveSpy).not.toHaveBeenCalled()
+
+    render(
+      <Bubble
+        user={{ _id: 1 }}
+        currentMessage={DEFAULT_TEST_MESSAGE}
+        position='left'
+        reactions={REACTIONS}
+        onPressMessage={jest.fn()}
+      />
+    )
+
+    expect(exclusiveSpy).toHaveBeenCalled()
+
+    exclusiveSpy.mockRestore()
+  })
 })

--- a/src/__tests__/MessagesContainerFlashList.test.tsx
+++ b/src/__tests__/MessagesContainerFlashList.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+
+import { MessagesContainer } from '..'
+import { DEFAULT_TEST_MESSAGE } from './data'
+
+const mockFlashListProps: Record<string, any>[] = []
+
+jest.mock('@shopify/flash-list', () => {
+  const ReactActual = jest.requireActual('react')
+  const { View } = jest.requireActual('react-native')
+
+  return {
+    FlashList: ReactActual.forwardRef((props: Record<string, any>, ref: unknown) => {
+      mockFlashListProps.push(props)
+      return ReactActual.createElement(View, { testID: 'flash-list', ref })
+    }),
+  }
+})
+
+const MESSAGES = [
+  { ...DEFAULT_TEST_MESSAGE, _id: 'test1' },
+  { ...DEFAULT_TEST_MESSAGE, _id: 'test2' },
+]
+
+beforeEach(() => {
+  mockFlashListProps.length = 0
+})
+
+it('renders FlatList by default', () => {
+  const { queryByTestId } = render(
+    <MessagesContainer messages={MESSAGES} user={{ _id: 1 }} />
+  )
+
+  expect(queryByTestId('flash-list')).toBeNull()
+})
+
+it('renders FlashList when isFlashListEnabled is set', () => {
+  const { queryByTestId } = render(
+    <MessagesContainer messages={MESSAGES} user={{ _id: 1 }} isFlashListEnabled />
+  )
+
+  expect(queryByTestId('flash-list')).not.toBeNull()
+  expect(mockFlashListProps[0]!.data).toEqual(MESSAGES)
+  expect(mockFlashListProps[0]!.inverted).toBe(true)
+})
+
+it('starts rendering from the bottom only for non-inverted lists', () => {
+  render(
+    <MessagesContainer messages={MESSAGES} user={{ _id: 1 }} isFlashListEnabled />
+  )
+  expect(mockFlashListProps[0]!.maintainVisibleContentPosition.startRenderingFromBottom).toBe(false)
+
+  mockFlashListProps.length = 0
+
+  render(
+    <MessagesContainer messages={MESSAGES} user={{ _id: 1 }} isFlashListEnabled isInverted={false} />
+  )
+  expect(mockFlashListProps[0]!.maintainVisibleContentPosition.startRenderingFromBottom).toBe(true)
+})
+
+it('lets listProps override the FlashList defaults', () => {
+  render(
+    <MessagesContainer
+      messages={MESSAGES}
+      user={{ _id: 1 }}
+      isFlashListEnabled
+      listProps={{ maintainVisibleContentPosition: { disabled: true } } as any}
+    />
+  )
+
+  expect(mockFlashListProps[0]!.maintainVisibleContentPosition).toEqual({ disabled: true })
+})
+
+it('does not pass FlatList-only virtualization props to FlashList', () => {
+  render(
+    <MessagesContainer messages={MESSAGES} user={{ _id: 1 }} isFlashListEnabled />
+  )
+
+  expect(mockFlashListProps[0]).not.toHaveProperty('windowSize')
+  expect(mockFlashListProps[0]).not.toHaveProperty('maxToRenderPerBatch')
+  expect(mockFlashListProps[0]).not.toHaveProperty('updateCellsBatchingPeriod')
+})

--- a/src/__tests__/MessagesContainerFlashListMissing.test.tsx
+++ b/src/__tests__/MessagesContainerFlashListMissing.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+
+import { MessagesContainer } from '..'
+import { DEFAULT_TEST_MESSAGE } from './data'
+
+// Simulate a consumer that opted into FlashList without installing it.
+jest.mock('@shopify/flash-list', () => {
+  throw new Error('Cannot find module @shopify/flash-list')
+})
+
+it('falls back to FlatList and warns when @shopify/flash-list is missing', () => {
+  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+  expect(() => render(
+    <MessagesContainer
+      messages={[DEFAULT_TEST_MESSAGE]}
+      user={{ _id: 1 }}
+      isFlashListEnabled
+    />
+  )).not.toThrow()
+
+  expect(logSpy.mock.calls.some(call => call.join(' ').includes('@shopify/flash-list'))).toBe(true)
+
+  logSpy.mockRestore()
+})

--- a/src/__tests__/__snapshots__/Bubble.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Bubble.test.tsx.snap
@@ -1,7 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should render <Bubble /> and compare with snapshot 1`] = `
-<View>
+<View
+  style={
+    [
+      {
+        "alignItems": "flex-start",
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
   <View
     style={
       [
@@ -9,6 +19,7 @@ exports[`should render <Bubble /> and compare with snapshot 1`] = `
           "backgroundColor": "#f0f0f0",
           "borderRadius": 15,
           "justifyContent": "flex-end",
+          "maxWidth": "70%",
           "minHeight": 20,
         },
         null,

--- a/src/__tests__/__snapshots__/Message.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Message.test.tsx.snap
@@ -11,8 +11,7 @@ exports[`Message component should render <Message /> and compare with snapshot 1
           "alignItems": "flex-end",
           "flexDirection": "row",
           "justifyContent": "flex-start",
-          "marginLeft": 8,
-          "maxWidth": "70%",
+          "marginHorizontal": 8,
         },
         {
           "marginBottom": 10,
@@ -24,7 +23,17 @@ exports[`Message component should render <Message /> and compare with snapshot 1
       ]
     }
   >
-    <View>
+    <View
+      style={
+        [
+          {
+            "alignItems": "flex-start",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
       <View
         style={
           [
@@ -32,6 +41,7 @@ exports[`Message component should render <Message /> and compare with snapshot 1
               "backgroundColor": "#f0f0f0",
               "borderRadius": 15,
               "justifyContent": "flex-end",
+              "maxWidth": "70%",
               "minHeight": 20,
             },
             null,
@@ -154,8 +164,7 @@ exports[`Message component should render <Message /> with Avatar 1`] = `
           "alignItems": "flex-end",
           "flexDirection": "row",
           "justifyContent": "flex-start",
-          "marginLeft": 8,
-          "maxWidth": "70%",
+          "marginHorizontal": 8,
         },
         {
           "marginBottom": 10,
@@ -206,7 +215,17 @@ exports[`Message component should render <Message /> with Avatar 1`] = `
         }
       />
     </View>
-    <View>
+    <View
+      style={
+        [
+          {
+            "alignItems": "flex-start",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
       <View
         style={
           [
@@ -214,6 +233,7 @@ exports[`Message component should render <Message /> with Avatar 1`] = `
               "backgroundColor": "#f0f0f0",
               "borderRadius": 15,
               "justifyContent": "flex-end",
+              "maxWidth": "70%",
               "minHeight": 20,
             },
             null,
@@ -336,8 +356,7 @@ exports[`Message component should render null if user has no Avatar 1`] = `
           "alignItems": "flex-end",
           "flexDirection": "row",
           "justifyContent": "flex-start",
-          "marginLeft": 8,
-          "maxWidth": "70%",
+          "marginHorizontal": 8,
         },
         {
           "marginBottom": 10,
@@ -388,7 +407,17 @@ exports[`Message component should render null if user has no Avatar 1`] = `
         }
       />
     </View>
-    <View>
+    <View
+      style={
+        [
+          {
+            "alignItems": "flex-start",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
       <View
         style={
           [
@@ -396,6 +425,7 @@ exports[`Message component should render null if user has no Avatar 1`] = `
               "backgroundColor": "#f0f0f0",
               "borderRadius": 15,
               "justifyContent": "flex-end",
+              "maxWidth": "70%",
               "minHeight": 20,
             },
             null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,6 +1869,11 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
+"@shopify/flash-list@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-2.3.2.tgz#d96a00f2195629b070117f1eaabc12f8b25be8f1"
+  integrity sha512-vQnd0y0Ag11yzS30llaeCrtIU3xYTMe7KEOP3dveLImnVjQEUw6BEg1+Ztja6aODlVNz1BpvxtlQ5eZGxiLwKw==
+
 "@sideway/address@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"


### PR DESCRIPTION
Ports the fixes for #1 and #3 onto the `main` (4.1.x) line. The same work is already on the `4.2.0` branch in 299d337; this is the equivalent adapted to main's code (no theming layer, no `messageActions`).

## #1 - video controls dead when reactions are enabled

The bubble's gestures ran with react-native-gesture-handler's default `cancelsTouchesInView` (which is `YES` on iOS), so the moment a recognizer won, UIKit cancelled touches on native subviews and a `react-native-video` / `expo-video` player rendered through `renderMessageVideo` never received its play / seek / fullscreen taps. On top of that a `Gesture.Tap()` was attached unconditionally, even with no `onPressMessage`, so it competed for every tap for nothing.

- both recognizers now set `.cancelsTouchesInView(false)`
- the tap gesture is only composed in when `onPressMessage` is provided

## Row-wide press surface

The long-press surface now spans the whole message row rather than just the bubble, so pressing the empty space beside a bubble opens the reaction picker - matching Telegram on Android.

New `isMessageGestureEnabled` prop (bool or per-message predicate) opts a message's bubble out of that surface for content that must own its touches. The surface moves *behind* the bubble instead of disappearing, so long-pressing beside the bubble still opens the picker and reactions are never lost for that message.

## #3 - optional FlashList engine

`isFlashListEnabled` renders messages with `@shopify/flash-list` v2, which recycles rows and removes the `VirtualizedList: You have a large list that is slow to update` warning on long histories. The package is an **optional** peer dependency - when missing, the prop is ignored, a warning is logged, and `FlatList` is used. `maintainVisibleContentPosition` is wired up (`startRenderingFromBottom` on non-inverted lists, `autoscrollToBottomThreshold: 0.2`) and `listProps` still overrides everything.

The day header needed one adjustment: FlashList hands its `CellRendererComponent` only an `index` and no `item`, so the message is looked up through a ref to keep the component identity stable - recreating it would remount every row and defeat recycling.

## Behaviour changes to be aware of

- **Bubble width**: the message row is full-width now and the 70% cap moved onto the bubble, so bubbles beside an avatar get slightly more room (70% is measured against the row minus the avatar rather than including it).
- `QuickReplies` and the reaction pills are no longer clamped to the bubble's width - they hug their own content, aligned to the sender's side.
- These are visual changes on a released line; worth a version bump rather than a pure patch.

## Verification

`yarn typecheck`, `eslint src` (0 errors, 9 pre-existing warnings), `yarn build` and `yarn test` (24 suites / 51 tests) pass. 4 snapshots updated for the layout change. 11 tests cover the gesture composition, `cancelsTouchesInView`, the `isMessageGestureEnabled` predicate, the FlashList/FlatList switch, the MVCP defaults and overrides, and the missing-package fallback.

The row-wide press, picker anchoring and context-menu behaviour were checked on an iOS simulator against the `4.2.0` branch (same code path). Two things are **not** device-verified: the video-controls fix itself (no `react-native-video` setup here) and the FlashList path (unit-tested against a mocked FlashList, not real rendering).
